### PR TITLE
[STEP-3] 이커머스 시스템 클린아키텍처 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("com.google.guava:guava:32.0.1-jre")
 
     // DB
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,11 @@ dependencies {
 	runtimeOnly("com.mysql:mysql-connector-j")
 
     // Test
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+	compileOnly("org.projectlombok:lombok:1.18.30")
+	annotationProcessor("org.projectlombok:lombok:1.18.30")
+	testCompileOnly("org.projectlombok:lombok:1.18.30")
+	testAnnotationProcessor("org.projectlombok:lombok:1.18.30")
+	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.boot:spring-boot-testcontainers")
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")

--- a/src/main/java/kr/hhplus/be/server/application/order/dto/OrderItem.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/dto/OrderItem.java
@@ -2,15 +2,12 @@ package kr.hhplus.be.server.application.order.dto;
 
 import lombok.*;
 
-import java.math.BigDecimal;
-
 @Getter
 @Setter
 @AllArgsConstructor
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class OrderProduct {
+public class OrderItem {
     private Long productId;
     private int quantity;
-    private BigDecimal price;
 }

--- a/src/main/java/kr/hhplus/be/server/application/order/dto/OrderProduct.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/dto/OrderProduct.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.application.order.dto;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderProduct {
+    private Long productId;
+    private int quantity;
+    private BigDecimal price;
+}

--- a/src/main/java/kr/hhplus/be/server/application/order/dto/OrderRequest.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/dto/OrderRequest.java
@@ -1,7 +1,10 @@
 package kr.hhplus.be.server.application.order.dto;
 
+import kr.hhplus.be.server.domain.exception.ErrorCode;
+import kr.hhplus.be.server.domain.exception.OrderException;
+import kr.hhplus.be.server.domain.exception.UserException;
 import lombok.*;
-import org.springframework.util.ObjectUtils;
+import org.springframework.util.CollectionUtils;
 
 import java.util.List;
 
@@ -14,5 +17,16 @@ public class OrderRequest {
     private Long userId;
     private Long issuedCouponId;
     private Long totalPrice;
-    private List<OrderProduct> orderProducts;
+    private List<OrderItem> orderItems;
+
+    public void validation(){
+
+        if(userId == null){
+            throw new UserException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        if(CollectionUtils.isEmpty(orderItems)) {
+            throw new OrderException(ErrorCode.ORDER_PRODUCT_MISSING);
+        }
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/application/order/dto/OrderRequest.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/dto/OrderRequest.java
@@ -1,0 +1,18 @@
+package kr.hhplus.be.server.application.order.dto;
+
+import lombok.*;
+import org.springframework.util.ObjectUtils;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderRequest {
+    private Long userId;
+    private Long issuedCouponId;
+    private Long totalPrice;
+    private List<OrderProduct> orderProducts;
+}

--- a/src/main/java/kr/hhplus/be/server/application/order/dto/OrderResponse.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/dto/OrderResponse.java
@@ -1,6 +1,9 @@
 package kr.hhplus.be.server.application.order.dto;
 
+import kr.hhplus.be.server.domain.order.model.Order;
 import lombok.*;
+
+import java.math.BigDecimal;
 
 @Getter
 @Setter
@@ -8,4 +11,10 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderResponse {
+    private Long orderId;
+    private BigDecimal totalPrice;
+
+    public static OrderResponse from(Long orderId, Order order) {
+        return OrderResponse.builder().orderId(orderId).totalPrice(order.getTotalPrice()).build();
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/application/order/dto/OrderResponse.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/dto/OrderResponse.java
@@ -1,0 +1,11 @@
+package kr.hhplus.be.server.application.order.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderResponse {
+}

--- a/src/main/java/kr/hhplus/be/server/application/order/service/OrderService.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/service/OrderService.java
@@ -1,0 +1,37 @@
+package kr.hhplus.be.server.application.order.service;
+
+import kr.hhplus.be.server.application.order.dto.OrderProduct;
+import kr.hhplus.be.server.application.order.dto.OrderRequest;
+import kr.hhplus.be.server.application.order.dto.OrderResponse;
+import kr.hhplus.be.server.application.product.service.ProductService;
+import kr.hhplus.be.server.application.user.service.UserService;
+import kr.hhplus.be.server.domain.order.repository.OrderRepository;
+import kr.hhplus.be.server.domain.user.model.UserBalance;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+public class OrderService {
+    private OrderRepository orderRepository;
+    private UserService userService;
+    private ProductService productService;
+
+    @Transactional
+    public OrderResponse createOrder(OrderRequest orderRequest){
+        // 유저 검증을 위해 호출
+        userService.getUserBalance(orderRequest.getUserId());
+
+        // 상품 가격 가져오기
+
+        // totalPrice 계산
+
+        // 저장
+
+        // 재고 차감
+        for (OrderProduct orderProduct: orderRequest.getOrderProducts()) {
+            productService.decreaseProductInventory(orderProduct.getProductId(), orderProduct.getQuantity());
+        }
+
+        // 추후에 결제 event발행 - eventListner 처리 (@TransactionEventListener)
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/order/service/OrderService.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/service/OrderService.java
@@ -3,11 +3,14 @@ package kr.hhplus.be.server.application.order.service;
 import kr.hhplus.be.server.application.order.dto.OrderItem;
 import kr.hhplus.be.server.application.order.dto.OrderRequest;
 import kr.hhplus.be.server.application.order.dto.OrderResponse;
+import kr.hhplus.be.server.application.payment.dto.PaymentRequest;
+import kr.hhplus.be.server.application.payment.service.PaymentService;
 import kr.hhplus.be.server.application.product.dto.ProductOrderResult;
 import kr.hhplus.be.server.application.product.service.ProductService;
 import kr.hhplus.be.server.application.user.service.UserService;
 import kr.hhplus.be.server.domain.order.model.Order;
 import kr.hhplus.be.server.domain.order.repository.OrderRepository;
+import kr.hhplus.be.server.domain.payment.model.Payment;
 import kr.hhplus.be.server.domain.user.model.UserBalance;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +20,7 @@ public class OrderService {
     private OrderRepository orderRepository;
     private UserService userService;
     private ProductService productService;
+    private PaymentService paymentService;
 
     @Transactional
     public OrderResponse createOrder(OrderRequest orderRequest){
@@ -37,7 +41,14 @@ public class OrderService {
         }
 
         // 추후에 결제 event발행 - eventListner 처리 (@TransactionEventListener)
+        paymentService.createPayment(PaymentRequest.of(order));
 
         return OrderResponse.from(orderId, order);
+    }
+
+    /* 주문 취소 - 화면에서 주문 취소 OR 결제 실패 시 호출 */
+    @Transactional
+    public void cancelOrder(Long orderId){
+
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/order/service/OrderService.java
+++ b/src/main/java/kr/hhplus/be/server/application/order/service/OrderService.java
@@ -1,10 +1,12 @@
 package kr.hhplus.be.server.application.order.service;
 
-import kr.hhplus.be.server.application.order.dto.OrderProduct;
+import kr.hhplus.be.server.application.order.dto.OrderItem;
 import kr.hhplus.be.server.application.order.dto.OrderRequest;
 import kr.hhplus.be.server.application.order.dto.OrderResponse;
+import kr.hhplus.be.server.application.product.dto.ProductOrderResult;
 import kr.hhplus.be.server.application.product.service.ProductService;
 import kr.hhplus.be.server.application.user.service.UserService;
+import kr.hhplus.be.server.domain.order.model.Order;
 import kr.hhplus.be.server.domain.order.repository.OrderRepository;
 import kr.hhplus.be.server.domain.user.model.UserBalance;
 import lombok.RequiredArgsConstructor;
@@ -18,20 +20,24 @@ public class OrderService {
 
     @Transactional
     public OrderResponse createOrder(OrderRequest orderRequest){
+        orderRequest.validation();
         // 유저 검증을 위해 호출
-        userService.getUserBalance(orderRequest.getUserId());
+        UserBalance userBalance = userService.getUserBalance(orderRequest.getUserId());
 
-        // 상품 가격 가져오기
-
-        // totalPrice 계산
+        // totalPrice 계산가져오기
+        ProductOrderResult productOrderResult = productService.getProductOrderPrice(orderRequest.getOrderItems());
 
         // 저장
+        Order order = Order.of(orderRequest, productOrderResult);
+        Long orderId = orderRepository.save(order);
 
         // 재고 차감
-        for (OrderProduct orderProduct: orderRequest.getOrderProducts()) {
-            productService.decreaseProductInventory(orderProduct.getProductId(), orderProduct.getQuantity());
+        for (OrderItem orderItem : orderRequest.getOrderItems()) {
+            productService.decreaseProductInventory(orderItem.getProductId(), orderItem.getQuantity());
         }
 
         // 추후에 결제 event발행 - eventListner 처리 (@TransactionEventListener)
+
+        return OrderResponse.from(orderId, order);
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/payment/dto/PaymentRequest.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/dto/PaymentRequest.java
@@ -1,6 +1,8 @@
 package kr.hhplus.be.server.application.payment.dto;
 
+import kr.hhplus.be.server.domain.order.model.Order;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -9,8 +11,13 @@ import java.math.BigDecimal;
 @Getter
 @Setter
 @AllArgsConstructor
+@Builder
 public class PaymentRequest {
     private Long orderId;
     private Long userId;
     private BigDecimal totalPrice;
+
+    public static PaymentRequest of(Order order) {
+        return PaymentRequest.builder().userId(order.getUserId()).orderId(order.getId()).totalPrice(order.getTotalPrice()).build();
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/application/payment/dto/PaymentRequest.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/dto/PaymentRequest.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.application.payment.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PaymentRequest {
+    private Long orderId;
+    private Long userId;
+    private BigDecimal totalPrice;
+}

--- a/src/main/java/kr/hhplus/be/server/application/payment/dto/PaymentResponse.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/dto/PaymentResponse.java
@@ -1,0 +1,27 @@
+package kr.hhplus.be.server.application.payment.dto;
+
+import kr.hhplus.be.server.domain.payment.enumtype.PaymentStatus;
+import kr.hhplus.be.server.domain.payment.model.Payment;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PaymentResponse {
+    private Long paymentId;
+    private Long orderId;
+    private LocalDate paymentDate;
+    private PaymentStatus paymentStatus;
+
+    public static PaymentResponse of(Payment payment) {
+        return PaymentResponse.builder()
+                .paymentId(payment.getId())
+                .orderId(payment.getOrderId())
+                .paymentDate(payment.getPaymentDate())
+                .paymentStatus(payment.getPaymentStatus()).build();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/payment/service/PaymentService.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/service/PaymentService.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.application.payment.service;
+
+import kr.hhplus.be.server.application.payment.dto.PaymentRequest;
+import kr.hhplus.be.server.application.payment.dto.PaymentResponse;
+import kr.hhplus.be.server.application.user.dto.UserBalanceRequest;
+import kr.hhplus.be.server.application.user.service.UserService;
+import kr.hhplus.be.server.domain.payment.model.Payment;
+import kr.hhplus.be.server.domain.payment.repository.PaymentRepository;
+import kr.hhplus.be.server.domain.user.model.UserBalance;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class PaymentService {
+    private final PaymentRepository paymentRepository;
+    private final UserService userService;
+
+    public PaymentResponse createPayment(PaymentRequest paymentRequest) {
+        // 포인트 사용
+        UserBalanceRequest userBalanceRequest = UserBalanceRequest.builder().id(paymentRequest.getUserId()).amount(paymentRequest.getTotalPrice()).build();
+        UserBalance userBalance = userService.useUserBalance(userBalanceRequest);
+
+        // 결제 내역 저장
+        Payment payment = paymentRepository.save(Payment.from(paymentRequest));
+
+        // 추후 이벤트 리스너로 주문 상태변경 이벤트 발행 (PENDING > COMPLETED)
+
+        return PaymentResponse.of(payment);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/payment/service/PaymentService.java
+++ b/src/main/java/kr/hhplus/be/server/application/payment/service/PaymentService.java
@@ -8,12 +8,14 @@ import kr.hhplus.be.server.domain.payment.model.Payment;
 import kr.hhplus.be.server.domain.payment.repository.PaymentRepository;
 import kr.hhplus.be.server.domain.user.model.UserBalance;
 import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 public class PaymentService {
     private final PaymentRepository paymentRepository;
     private final UserService userService;
 
+    @Transactional
     public PaymentResponse createPayment(PaymentRequest paymentRequest) {
         // 포인트 사용
         UserBalanceRequest userBalanceRequest = UserBalanceRequest.builder().id(paymentRequest.getUserId()).amount(paymentRequest.getTotalPrice()).build();

--- a/src/main/java/kr/hhplus/be/server/application/product/dto/ProductOrderDetail.java
+++ b/src/main/java/kr/hhplus/be/server/application/product/dto/ProductOrderDetail.java
@@ -1,0 +1,32 @@
+package kr.hhplus.be.server.application.product.dto;
+
+import kr.hhplus.be.server.application.order.dto.OrderItem;
+import kr.hhplus.be.server.domain.exception.ErrorCode;
+import kr.hhplus.be.server.domain.exception.ProductException;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductOrderDetail {
+    private Long productId;
+    private int quantity;
+    private BigDecimal price;
+
+    public static ProductOrderDetail of(OrderItem orderItem, BigDecimal price) {
+
+        if (price == null){
+            throw new ProductException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+
+        ProductOrderDetail productOrderDetail = new ProductOrderDetail();
+        productOrderDetail.setProductId(orderItem.getProductId());
+        productOrderDetail.setQuantity(orderItem.getQuantity());
+        productOrderDetail.setPrice(price);
+        return productOrderDetail;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/product/dto/ProductOrderResult.java
+++ b/src/main/java/kr/hhplus/be/server/application/product/dto/ProductOrderResult.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.application.product.dto;
+
+import lombok.*;
+import org.checkerframework.checker.units.qual.A;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProductOrderResult {
+    private BigDecimal totalPrice;
+    private List<ProductOrderDetail> productOrderDetails;
+
+    public static ProductOrderResult of(BigDecimal totalPrice, List<ProductOrderDetail> productOrderDetails) {
+        return new ProductOrderResult(totalPrice, productOrderDetails);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/product/dto/ProductSearchRequest.java
+++ b/src/main/java/kr/hhplus/be/server/application/product/dto/ProductSearchRequest.java
@@ -21,7 +21,7 @@ public class ProductSearchRequest {
     private Integer size;
     private Integer pageNo;
 
-    public void validate() {
+    public void validation() {
         if (minPrice != null && minPrice.compareTo(BigDecimal.ZERO) < 0) {
             throw new ProductException(ErrorCode.MIN_PRICE);
         }

--- a/src/main/java/kr/hhplus/be/server/application/product/dto/ProductSearchRequest.java
+++ b/src/main/java/kr/hhplus/be/server/application/product/dto/ProductSearchRequest.java
@@ -1,0 +1,35 @@
+package kr.hhplus.be.server.application.product.dto;
+
+import kr.hhplus.be.server.domain.exception.ErrorCode;
+import kr.hhplus.be.server.domain.exception.ProductException;
+import kr.hhplus.be.server.domain.product.enumtype.ProductCategory;
+import lombok.*;
+import org.springframework.util.ObjectUtils;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public class ProductSearchRequest {
+    /* TODO : Enum 타입 검증 추가 */
+    private ProductCategory category;
+    private BigDecimal minPrice;
+    private BigDecimal maxPrice;
+    private Integer size;
+    private Integer pageNo;
+
+    public void validate() {
+        if (minPrice != null && minPrice.compareTo(BigDecimal.ZERO) < 0) {
+            throw new ProductException(ErrorCode.MIN_PRICE);
+        }
+        if (maxPrice != null && maxPrice.compareTo(BigDecimal.valueOf(100000000)) > 0){
+            throw new ProductException(ErrorCode.MAX_PRICE);
+        }
+        if (ObjectUtils.isEmpty(size) || ObjectUtils.isEmpty(pageNo)) {
+            throw new ProductException(ErrorCode.MISSING_PAGE_PARAMETER);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/product/service/ProductService.java
+++ b/src/main/java/kr/hhplus/be/server/application/product/service/ProductService.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.application.product.service;
+
+import kr.hhplus.be.server.application.product.dto.ProductSearchRequest;
+import kr.hhplus.be.server.domain.product.model.Product;
+import kr.hhplus.be.server.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public Page<Product> getProducts(ProductSearchRequest productSearchRequest) {
+        productSearchRequest.validate();
+        Pageable pageable = PageRequest.of(productSearchRequest.getPageNo(), productSearchRequest.getSize());
+        return productRepository.getProducts(productSearchRequest, pageable);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/application/product/service/ProductService.java
+++ b/src/main/java/kr/hhplus/be/server/application/product/service/ProductService.java
@@ -1,5 +1,8 @@
 package kr.hhplus.be.server.application.product.service;
 
+import kr.hhplus.be.server.application.order.dto.OrderItem;
+import kr.hhplus.be.server.application.product.dto.ProductOrderDetail;
+import kr.hhplus.be.server.application.product.dto.ProductOrderResult;
 import kr.hhplus.be.server.application.product.dto.ProductSearchRequest;
 import kr.hhplus.be.server.domain.product.model.Product;
 import kr.hhplus.be.server.domain.product.model.ProductInventory;
@@ -8,6 +11,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -32,6 +39,20 @@ public class ProductService {
         ProductInventory productInventory =  productRepository.getProductInventory(productId);
         productInventory.decreaseProductInventory(orderQuantity);
         productRepository.saveProductInventory(productInventory);
+
+    }
+
+    public ProductOrderResult getProductOrderPrice(List<OrderItem> orderItems) {
+        List<ProductOrderDetail> productOrderDetails = new ArrayList<>();
+        BigDecimal totalPrice = BigDecimal.ZERO;
+
+        for (OrderItem orderItem : orderItems) {
+            BigDecimal productPrice = productRepository.getProductPrice(orderItem.getProductId());
+            productOrderDetails.add(ProductOrderDetail.of(orderItem, productPrice));
+            totalPrice = totalPrice.add(productPrice.multiply(BigDecimal.valueOf(orderItem.getQuantity())));
+        }
+
+        return ProductOrderResult.of(totalPrice, productOrderDetails);
 
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/product/service/ProductService.java
+++ b/src/main/java/kr/hhplus/be/server/application/product/service/ProductService.java
@@ -2,6 +2,7 @@ package kr.hhplus.be.server.application.product.service;
 
 import kr.hhplus.be.server.application.product.dto.ProductSearchRequest;
 import kr.hhplus.be.server.domain.product.model.Product;
+import kr.hhplus.be.server.domain.product.model.ProductInventory;
 import kr.hhplus.be.server.domain.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -14,9 +15,23 @@ public class ProductService {
 
     private final ProductRepository productRepository;
 
+    /*
+        상품 조회
+     */
     public Page<Product> getProducts(ProductSearchRequest productSearchRequest) {
-        productSearchRequest.validate();
+        productSearchRequest.validation();
         Pageable pageable = PageRequest.of(productSearchRequest.getPageNo(), productSearchRequest.getSize());
         return productRepository.getProducts(productSearchRequest, pageable);
+    }
+
+
+    /*
+        상품 재고 차감
+     */
+    public void decreaseProductInventory(Long productId, int orderQuantity){
+        ProductInventory productInventory =  productRepository.getProductInventory(productId);
+        productInventory.decreaseProductInventory(orderQuantity);
+        productRepository.saveProductInventory(productInventory);
+
     }
 }

--- a/src/main/java/kr/hhplus/be/server/application/user/dto/UserBalanceRequest.java
+++ b/src/main/java/kr/hhplus/be/server/application/user/dto/UserBalanceRequest.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.application.user.dto;
+
+import kr.hhplus.be.server.domain.user.enumtype.TransactionType;
+import lombok.*;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+@AllArgsConstructor
+@Builder
+public class UserBalanceRequest {
+    private Long id;
+    private BigDecimal amount;
+}

--- a/src/main/java/kr/hhplus/be/server/application/user/service/UserService.java
+++ b/src/main/java/kr/hhplus/be/server/application/user/service/UserService.java
@@ -1,0 +1,62 @@
+package kr.hhplus.be.server.application.user.service;
+
+import com.google.common.util.concurrent.Striped;
+import kr.hhplus.be.server.application.user.dto.UserBalanceRequest;
+import kr.hhplus.be.server.domain.exception.ErrorCode;
+import kr.hhplus.be.server.domain.exception.UserException;
+import kr.hhplus.be.server.domain.user.enumtype.TransactionType;
+import kr.hhplus.be.server.domain.user.model.UserBalance;
+import kr.hhplus.be.server.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.ObjectUtils;
+
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    private final Striped<Lock> stripedLocks = Striped.lazyWeakLock(1024);
+
+    @Transactional
+    public UserBalance chargeUserBalance(UserBalanceRequest userBalanceRequest){
+        Lock lock = stripedLocks.get(userBalanceRequest.getId());
+
+        boolean acquired = false;
+
+        try {
+            acquired = lock.tryLock(5, TimeUnit.SECONDS);
+
+            if (!acquired) {
+                throw new ConcurrentModificationException(
+                        "다른 거래가 진행 중입니다. 잠시 후 다시 시도해주세요."
+                );
+            }
+
+            UserBalance userBalance = userRepository.getUserBalance(userBalanceRequest.getId());
+            if (ObjectUtils.isEmpty(userBalance)) {
+                throw new UserException(ErrorCode.USER_NOT_FOUND);
+            }
+
+            UserBalance afterChargeUserBalance = userBalance.chargeBalance(userBalanceRequest.getAmount());
+            int cnt = userRepository.chargeUserBalance(afterChargeUserBalance); // 잔액 충전
+
+            if (cnt == 0) {
+                throw new UserException(ErrorCode.CHARGE_BALANCE_FAILED);
+            }
+            userRepository.insertUserBalanceHistory(afterChargeUserBalance.getId(), TransactionType.CHARGE, userBalanceRequest.getAmount());
+
+            return afterChargeUserBalance;
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (acquired) {
+                lock.unlock();
+            }
+        }
+
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/exception/ApiControllerAdvice.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/ApiControllerAdvice.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.domain.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class ApiControllerAdvice extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(value = Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorResponse("Internal Server Error", e.getMessage()));
+    }
+
+    @ExceptionHandler(value = ProductException.class)
+    public ResponseEntity<ErrorResponse> handleException(ProductException e) {
+        return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/exception/ApiControllerAdvice.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/ApiControllerAdvice.java
@@ -17,4 +17,9 @@ public class ApiControllerAdvice extends ResponseEntityExceptionHandler {
     public ResponseEntity<ErrorResponse> handleException(ProductException e) {
         return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getCode(), e.getMessage()));
     }
+
+    @ExceptionHandler(value = UserException.class)
+    public ResponseEntity<ErrorResponse> handleException(UserException e) {
+        return ResponseEntity.status(e.getHttpStatus()).body(new ErrorResponse(e.getCode(), e.getMessage()));
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/exception/ErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
 
 
     INVALID_CHARGE_AMOUNT("INVALID_CHARGE_AMOUNT", "유효하지 않은 충전 금액입니다.", HttpStatus.BAD_REQUEST),
-    MIN_CHARGE_AMOUNT("MIN_CHARGE_AMOUNT", "1회 최소 충전 가능 금액은 1000원입니다.", HttpStatus.BAD_REQUEST),
+    MIN_CHARGE_AMOUNT("MIN_CHARGE_AMOUNT", "1회 최소 충전 가능 금액은 1,000원입니다.", HttpStatus.BAD_REQUEST),
     MAX_CHARGE_AMOUNT("MAX_CHARGE_AMOUNT", "1회 최대 충전 가능 금액은 5,000,000원입니다.", HttpStatus.BAD_REQUEST),
     EXCEED_MAX_BALANCE("EXCEED_MAX_BALANCE", "최대 보유 가능 잔액은 10,000,000원입니다.", HttpStatus.UNPROCESSABLE_ENTITY), // 클라이언트가 올바른 요청을 보냈지만, 서버가 요청을 처리할 수 없음 (서버 내부 정책에 의하여 처리 불가)
 
@@ -40,6 +40,7 @@ public enum ErrorCode {
     INVALID_STATUS("INVALID_STATUS", "유효하지 않은 상태 조건 입니다.", HttpStatus.BAD_REQUEST),
 
 
+    CHARGE_BALANCE_FAILED("CHARGE_BALANCE_FAILED", "잔액 충전이 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     EXCEED_MAX_COUPON("EXCEED_MAX_COUPON", "최대 보유 가능한 쿠폰 매수를 초과했습니다.", HttpStatus.UNPROCESSABLE_ENTITY), // 클라이언트가 올바른 요청을 보냈지만, 서버가 요청을 처리할 수 없음 (서버 내부 정책에 의하여 처리 불가)
     COUPON_DOWNLOAD_TIME("COUPON_DOWNLOAD_TIME", "쿠폰 다운로드 시간이 아닙니다.", HttpStatus.BAD_REQUEST);
 

--- a/src/main/java/kr/hhplus/be/server/domain/exception/ErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/ErrorCode.java
@@ -1,0 +1,49 @@
+package kr.hhplus.be.server.domain.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    MIN_PRICE("MIN_PRICE", "조회 최소 금액은 0보다 작을 수 없습니다.", HttpStatus.BAD_REQUEST),
+    MAX_PRICE("MAX_PRICE", "최대 조회 가능 금액을 초과했습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_CATEGORY("INVALID_CATEGORY", "유효하지 않은 카테고리입니다.", HttpStatus.BAD_REQUEST),
+    MISSING_PAGE_PARAMETER("MISSING_PAGE_PARAMETER", "필수 페이지 파라미터가 누락되었습니다", HttpStatus.BAD_REQUEST),
+
+    USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    COUPON_NOT_FOUND("COUPON_NOT_FOUND", "존재하지 않는 쿠폰 번호입니다.", HttpStatus.NOT_FOUND),
+    PRODUCT_NOT_FOUND("PRODUCT_NOT_FOUND", "존재하지 않는 상품입니다.",  HttpStatus.NOT_FOUND),
+
+
+    OUT_OF_STOCK("OUT_OF_STOCK", "상품 재고가 부족합니다.", HttpStatus.CONFLICT),
+    INSUFFICIENT_BALANCE("INSUFFICIENT_BALANCE", "잔액이 부족합니다.", HttpStatus.CONFLICT),
+    DUPLICATE_PAYMENT("DUPLICATE_PAYMENT", "이미 결제가 완료되었습니다.", HttpStatus.CONFLICT),
+
+
+    PRICE_NOT_MATCH("PRICE_NOT_MATCH", "주문 금액이 정확하지 않습니다.", HttpStatus.BAD_REQUEST),
+    INVALID_QUANTITY("INVALID_QUANTITY", "상품을 1개 이상 주문해주세요.", HttpStatus.BAD_REQUEST),
+
+
+
+    INVALID_CHARGE_AMOUNT("INVALID_CHARGE_AMOUNT", "유효하지 않은 충전 금액입니다.", HttpStatus.BAD_REQUEST),
+    MIN_CHARGE_AMOUNT("MIN_CHARGE_AMOUNT", "1회 최소 충전 가능 금액은 1000원입니다.", HttpStatus.BAD_REQUEST),
+    MAX_CHARGE_AMOUNT("MAX_CHARGE_AMOUNT", "1회 최대 충전 가능 금액은 5,000,000원입니다.", HttpStatus.BAD_REQUEST),
+    EXCEED_MAX_BALANCE("EXCEED_MAX_BALANCE", "최대 보유 가능 잔액은 10,000,000원입니다.", HttpStatus.UNPROCESSABLE_ENTITY), // 클라이언트가 올바른 요청을 보냈지만, 서버가 요청을 처리할 수 없음 (서버 내부 정책에 의하여 처리 불가)
+
+
+
+    SEARCH_DATE_ERROR("SEARCH_DATE_ERROR", "검색 시작 일자는 검색 종료 일자보다 클 수 없습니다.", HttpStatus.BAD_REQUEST),
+    ORDER_TYPE_ERROR("ORDER_TYPE_ERROR", "유효하지 않은 정렬 방법입니다.", HttpStatus.BAD_REQUEST),
+    TRANSACTION_TYPE_ERROR("TRANSACTION_TYPE_ERROR", "유효하지 않은 트랜잭션 타입입니다.",  HttpStatus.BAD_REQUEST),
+    INVALID_STATUS("INVALID_STATUS", "유효하지 않은 상태 조건 입니다.", HttpStatus.BAD_REQUEST),
+
+
+    EXCEED_MAX_COUPON("EXCEED_MAX_COUPON", "최대 보유 가능한 쿠폰 매수를 초과했습니다.", HttpStatus.UNPROCESSABLE_ENTITY), // 클라이언트가 올바른 요청을 보냈지만, 서버가 요청을 처리할 수 없음 (서버 내부 정책에 의하여 처리 불가)
+    COUPON_DOWNLOAD_TIME("COUPON_DOWNLOAD_TIME", "쿠폰 다운로드 시간이 아닙니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/src/main/java/kr/hhplus/be/server/domain/exception/ErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/ErrorCode.java
@@ -28,6 +28,7 @@ public enum ErrorCode {
 
 
     INVALID_CHARGE_AMOUNT("INVALID_CHARGE_AMOUNT", "유효하지 않은 충전 금액입니다.", HttpStatus.BAD_REQUEST),
+    INVALID_USE_AMOUNT("INVALID_USE_AMOUNT", "유효하지 않은 사용 금액입니다.", HttpStatus.BAD_REQUEST),
     MIN_CHARGE_AMOUNT("MIN_CHARGE_AMOUNT", "1회 최소 충전 가능 금액은 1,000원입니다.", HttpStatus.BAD_REQUEST),
     MAX_CHARGE_AMOUNT("MAX_CHARGE_AMOUNT", "1회 최대 충전 가능 금액은 5,000,000원입니다.", HttpStatus.BAD_REQUEST),
     EXCEED_MAX_BALANCE("EXCEED_MAX_BALANCE", "최대 보유 가능 잔액은 10,000,000원입니다.", HttpStatus.UNPROCESSABLE_ENTITY), // 클라이언트가 올바른 요청을 보냈지만, 서버가 요청을 처리할 수 없음 (서버 내부 정책에 의하여 처리 불가)

--- a/src/main/java/kr/hhplus/be/server/domain/exception/ErrorCode.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/ErrorCode.java
@@ -22,7 +22,7 @@ public enum ErrorCode {
     DUPLICATE_PAYMENT("DUPLICATE_PAYMENT", "이미 결제가 완료되었습니다.", HttpStatus.CONFLICT),
 
 
-    PRICE_NOT_MATCH("PRICE_NOT_MATCH", "주문 금액이 정확하지 않습니다.", HttpStatus.BAD_REQUEST),
+    ORDER_PRODUCT_MISSING("ORDER_PRODUCT_MISSING", "주문 상품이 없습니다.", HttpStatus.BAD_REQUEST),
     INVALID_QUANTITY("INVALID_QUANTITY", "상품을 1개 이상 주문해주세요.", HttpStatus.BAD_REQUEST),
 
 

--- a/src/main/java/kr/hhplus/be/server/domain/exception/ErrorResponse.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/ErrorResponse.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.exception;
+
+public record ErrorResponse(
+        String code,
+        String message
+) {
+}

--- a/src/main/java/kr/hhplus/be/server/domain/exception/OrderException.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/OrderException.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.domain.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class OrderException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public OrderException(ErrorCode code) {
+        super(code.getMessage());
+        this.errorCode = code;
+    }
+
+    public String getCode(){
+        return errorCode.getCode();
+    }
+
+    public HttpStatus getHttpStatus(){
+        return errorCode.getHttpStatus();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/exception/ProductException.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/ProductException.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.domain.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ProductException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ProductException(ErrorCode code) {
+        super(code.getMessage());
+        this.errorCode = code;
+    }
+
+    public String getCode(){
+        return errorCode.getCode();
+    }
+
+    public HttpStatus getHttpStatus(){
+        return errorCode.getHttpStatus();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/exception/UserException.java
+++ b/src/main/java/kr/hhplus/be/server/domain/exception/UserException.java
@@ -1,0 +1,23 @@
+package kr.hhplus.be.server.domain.exception;
+
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class UserException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public UserException(ErrorCode code) {
+        super(code.getMessage());
+        this.errorCode = code;
+    }
+
+    public String getCode(){
+        return errorCode.getCode();
+    }
+
+    public HttpStatus getHttpStatus(){
+        return errorCode.getHttpStatus();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/order/enumtype/OrderStatus.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/enumtype/OrderStatus.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.order.enumtype;
+
+public enum OrderStatus {
+    PENDING,
+    COMPLETED,
+    CANCELLED
+}

--- a/src/main/java/kr/hhplus/be/server/domain/order/model/Order.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/model/Order.java
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.domain.order.model;
+
+import kr.hhplus.be.server.application.order.dto.OrderRequest;
+import kr.hhplus.be.server.application.product.dto.ProductOrderResult;
+import kr.hhplus.be.server.domain.order.enumtype.OrderStatus;
+import lombok.*;
+import org.checkerframework.checker.units.qual.N;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+@Builder
+public class Order {
+    private Long id;
+    private Long userId;
+    private LocalDate orderDate;
+    private BigDecimal totalPrice;
+    private Long issuedCouponId;
+    private OrderStatus orderStatus;
+    private LocalDateTime voidedAt;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+
+    public static Order of(OrderRequest orderRequest, ProductOrderResult productOrderResult){
+        return Order.builder().userId(orderRequest.getUserId())
+                .orderDate(LocalDate.now())
+                .totalPrice(productOrderResult.getTotalPrice())
+                .issuedCouponId(orderRequest.getIssuedCouponId())
+                .orderStatus(OrderStatus.PENDING)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now()).build();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/order/model/OrderDetail.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/model/OrderDetail.java
@@ -1,0 +1,17 @@
+package kr.hhplus.be.server.domain.order.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+public class OrderDetail {
+    private Long id;
+    private Long orderId;
+    private Long productId;
+    private int quantity;
+    private BigDecimal price;
+    private BigDecimal totalPrice;
+}

--- a/src/main/java/kr/hhplus/be/server/domain/order/repository/OrderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/repository/OrderRepository.java
@@ -1,4 +1,8 @@
 package kr.hhplus.be.server.domain.order.repository;
 
+import kr.hhplus.be.server.domain.order.model.Order;
+
 public interface OrderRepository {
+    // 내부에서 Order 테이블, OrderDetail 테이블 모두 저장하고 orderId 반환
+    Long save(Order of);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/order/repository/OrderRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/order/repository/OrderRepository.java
@@ -1,0 +1,4 @@
+package kr.hhplus.be.server.domain.order.repository;
+
+public interface OrderRepository {
+}

--- a/src/main/java/kr/hhplus/be/server/domain/payment/enumtype/PaymentStatus.java
+++ b/src/main/java/kr/hhplus/be/server/domain/payment/enumtype/PaymentStatus.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.payment.enumtype;
+
+public enum PaymentStatus {
+    COMPLETED,
+    FAILED,
+    CANCLED
+}

--- a/src/main/java/kr/hhplus/be/server/domain/payment/model/Payment.java
+++ b/src/main/java/kr/hhplus/be/server/domain/payment/model/Payment.java
@@ -1,0 +1,39 @@
+package kr.hhplus.be.server.domain.payment.model;
+
+import kr.hhplus.be.server.application.payment.dto.PaymentRequest;
+import kr.hhplus.be.server.domain.payment.enumtype.PaymentStatus;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Payment {
+    private Long id;
+    private Long orderId;
+    private LocalDate paymentDate;
+    private BigDecimal payAmount;
+    private PaymentStatus paymentStatus;
+    private String paymentFailureReason;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static Payment from(PaymentRequest paymentRequest) {
+        return Payment.builder()
+                .orderId(paymentRequest.getOrderId())
+                .paymentDate(LocalDate.now())
+                .payAmount(paymentRequest.getTotalPrice())
+                .paymentStatus(PaymentStatus.COMPLETED)
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now()).build();
+    }
+
+    void assignId(Long id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/payment/repository/PaymentRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/payment/repository/PaymentRepository.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.payment.repository;
+
+import kr.hhplus.be.server.domain.payment.model.Payment;
+
+public interface PaymentRepository {
+    Payment save(Payment from);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/product/enumtype/ProductCategory.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/enumtype/ProductCategory.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.domain.product.enumtype;
+
+public enum ProductCategory {
+    ALL,
+    FASHION,
+    ELECTRONICS
+}

--- a/src/main/java/kr/hhplus/be/server/domain/product/model/Product.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/model/Product.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.domain.product.model;
+
+import kr.hhplus.be.server.domain.product.enumtype.ProductCategory;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@ToString
+public class Product {
+    private Long id;
+    private ProductCategory category;
+    private String productName;
+    private BigDecimal price;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/kr/hhplus/be/server/domain/product/model/ProductInventory.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/model/ProductInventory.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.domain.product.model;
+
+import kr.hhplus.be.server.domain.exception.ErrorCode;
+import kr.hhplus.be.server.domain.exception.ProductException;
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor(access = AccessLevel.PACKAGE)
+public class ProductInventory {
+    private Long productId;
+    private int inventory;
+
+    public void decreaseProductInventory(int orderQuantity){
+        validation(orderQuantity, inventory);
+        inventory -= orderQuantity;
+    }
+
+    private void validation(int orderQuantity, int inventory){
+        if(orderQuantity > inventory){
+            throw new ProductException(ErrorCode.OUT_OF_STOCK);
+        }
+        if(orderQuantity < 1){
+            throw new ProductException(ErrorCode.INVALID_QUANTITY);
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/product/repository/ProductRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/repository/ProductRepository.java
@@ -1,0 +1,10 @@
+package kr.hhplus.be.server.domain.product.repository;
+
+import kr.hhplus.be.server.application.product.dto.ProductSearchRequest;
+import kr.hhplus.be.server.domain.product.model.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ProductRepository {
+    Page<Product> getProducts(ProductSearchRequest productSearchRequest, Pageable pageable);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/product/repository/ProductRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/repository/ProductRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Lock;
 
+import java.math.BigDecimal;
+
 public interface ProductRepository {
     Page<Product> getProducts(ProductSearchRequest productSearchRequest, Pageable pageable);
 
@@ -15,4 +17,6 @@ public interface ProductRepository {
     ProductInventory getProductInventory(Long productId);
 
     int saveProductInventory(ProductInventory productInventory);
+
+    BigDecimal getProductPrice(Long productId);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/product/repository/ProductRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/product/repository/ProductRepository.java
@@ -1,10 +1,18 @@
 package kr.hhplus.be.server.domain.product.repository;
 
+import jakarta.persistence.LockModeType;
 import kr.hhplus.be.server.application.product.dto.ProductSearchRequest;
 import kr.hhplus.be.server.domain.product.model.Product;
+import kr.hhplus.be.server.domain.product.model.ProductInventory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
 
 public interface ProductRepository {
     Page<Product> getProducts(ProductSearchRequest productSearchRequest, Pageable pageable);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE) // 비관적락으로 재고 정합성 확보
+    ProductInventory getProductInventory(Long productId);
+
+    int saveProductInventory(ProductInventory productInventory);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/user/enumtype/TransactionType.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/enumtype/TransactionType.java
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.domain.user.enumtype;
+
+public enum TransactionType {
+    CHARGE,
+    USE
+}

--- a/src/main/java/kr/hhplus/be/server/domain/user/model/UserBalance.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/model/UserBalance.java
@@ -23,6 +23,14 @@ public class UserBalance {
         return new UserBalance(id, afterChargeBalance);
     }
 
+    public UserBalance useBalance(BigDecimal amount) {
+        validateUseAmount(amount);
+        BigDecimal afterUseBalance = balance.subtract(amount);
+        validateAfterUseAmount(afterUseBalance);
+        return new UserBalance(id, afterUseBalance);
+    }
+
+
     // 충전 금액 검증
     private void validateChargeAmount(BigDecimal amount) {
         if(amount.compareTo(BigDecimal.valueOf(1000)) < 0) {
@@ -34,6 +42,13 @@ public class UserBalance {
         }
     }
 
+    // 사용 금액 검증
+    private void validateUseAmount(BigDecimal amount) {
+        if(amount.compareTo(BigDecimal.ZERO) < 1) {
+            throw new UserException(ErrorCode.INVALID_USE_AMOUNT);
+        }
+    }
+
     // 충전 후 금액 검증 (최대 보유 금액)
     private void validateAfterChargeAmount(BigDecimal afterChargeBalance) {
         if(afterChargeBalance.compareTo(BigDecimal.valueOf(10000000)) > 0) {
@@ -41,4 +56,13 @@ public class UserBalance {
         }
 
     }
+
+    // 사용 후 금액 검증
+    private void validateAfterUseAmount(BigDecimal afterUseBalance) {
+        if(afterUseBalance.compareTo(BigDecimal.ZERO) < 0) {
+            throw new UserException(ErrorCode.INSUFFICIENT_BALANCE);
+        }
+    }
+
+
 }

--- a/src/main/java/kr/hhplus/be/server/domain/user/model/UserBalance.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/model/UserBalance.java
@@ -1,0 +1,41 @@
+package kr.hhplus.be.server.domain.user.model;
+
+import kr.hhplus.be.server.domain.exception.ErrorCode;
+import kr.hhplus.be.server.domain.exception.UserException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class UserBalance {
+    private Long id;
+    private BigDecimal balance;
+
+    public UserBalance chargeBalance(BigDecimal amount) {
+        validateChargeAmount(amount);
+        BigDecimal afterChargeBalance = balance.add(amount);
+        validateAfterChargeAmount(afterChargeBalance);
+        return new UserBalance(id, afterChargeBalance);
+    }
+
+    private void validateChargeAmount(BigDecimal amount) {
+        if(amount.compareTo(BigDecimal.valueOf(1000)) < 0) {
+            throw new UserException(ErrorCode.MIN_CHARGE_AMOUNT);
+        }
+
+        if(amount.compareTo(BigDecimal.valueOf(5000000)) > 0){
+            throw new UserException(ErrorCode.MAX_CHARGE_AMOUNT);
+        }
+    }
+
+    private void validateAfterChargeAmount(BigDecimal afterChargeBalance) {
+        if(afterChargeBalance.compareTo(BigDecimal.valueOf(10000000)) > 0) {
+            throw new UserException(ErrorCode.EXCEED_MAX_BALANCE);
+        }
+
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/user/model/UserBalance.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/model/UserBalance.java
@@ -15,6 +15,7 @@ public class UserBalance {
     private Long id;
     private BigDecimal balance;
 
+    // 잔액 충전
     public UserBalance chargeBalance(BigDecimal amount) {
         validateChargeAmount(amount);
         BigDecimal afterChargeBalance = balance.add(amount);
@@ -22,6 +23,7 @@ public class UserBalance {
         return new UserBalance(id, afterChargeBalance);
     }
 
+    // 충전 금액 검증
     private void validateChargeAmount(BigDecimal amount) {
         if(amount.compareTo(BigDecimal.valueOf(1000)) < 0) {
             throw new UserException(ErrorCode.MIN_CHARGE_AMOUNT);
@@ -32,6 +34,7 @@ public class UserBalance {
         }
     }
 
+    // 충전 후 금액 검증 (최대 보유 금액)
     private void validateAfterChargeAmount(BigDecimal afterChargeBalance) {
         if(afterChargeBalance.compareTo(BigDecimal.valueOf(10000000)) > 0) {
             throw new UserException(ErrorCode.EXCEED_MAX_BALANCE);

--- a/src/main/java/kr/hhplus/be/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package kr.hhplus.be.server.domain.user.repository;
+
+import kr.hhplus.be.server.domain.user.enumtype.TransactionType;
+import kr.hhplus.be.server.domain.user.model.UserBalance;
+
+import java.math.BigDecimal;
+
+public interface UserRepository {
+
+    UserBalance getUserBalance(Long id);
+
+    int chargeUserBalance(UserBalance userBalance);
+
+    void insertUserBalanceHistory(Long id, TransactionType type, BigDecimal amount);
+
+}

--- a/src/main/java/kr/hhplus/be/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/user/repository/UserRepository.java
@@ -13,4 +13,5 @@ public interface UserRepository {
 
     void insertUserBalanceHistory(Long id, TransactionType type, BigDecimal amount);
 
+    int useUserBalance(UserBalance afterUseUserBalance);
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/product/ProductController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/product/ProductController.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.interfaces.product;
+
+import kr.hhplus.be.server.application.product.dto.ProductSearchRequest;
+import kr.hhplus.be.server.application.product.service.ProductService;
+import kr.hhplus.be.server.domain.product.model.Product;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @PostMapping("/api/v1/products")
+    public ResponseEntity<Page<Product>> getProducts(@RequestBody ProductSearchRequest request){
+        Page<Product> products = productService.getProducts(request);
+        return ResponseEntity.ok(products);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/interfaces/product/ProductController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/product/ProductController.java
@@ -6,16 +6,17 @@ import kr.hhplus.be.server.domain.product.model.Product;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RequiredArgsConstructor
 public class ProductController {
 
     private final ProductService productService;
 
-    @PostMapping("/api/v1/products")
-    public ResponseEntity<Page<Product>> getProducts(@RequestBody ProductSearchRequest request){
+    @GetMapping("/api/v1/products")
+    public ResponseEntity<Page<Product>> getProducts(@RequestParam ProductSearchRequest request){
         Page<Product> products = productService.getProducts(request);
         return ResponseEntity.ok(products);
     }

--- a/src/test/java/kr/hhplus/be/server/ProductServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/ProductServiceTest.java
@@ -1,0 +1,105 @@
+package kr.hhplus.be.server;
+
+
+import kr.hhplus.be.server.application.product.dto.ProductSearchRequest;
+import kr.hhplus.be.server.application.product.service.ProductService;
+import kr.hhplus.be.server.domain.exception.ProductException;
+import kr.hhplus.be.server.domain.product.enumtype.ProductCategory;
+import kr.hhplus.be.server.domain.product.model.Product;
+import kr.hhplus.be.server.domain.product.repository.ProductRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class ProductServiceTest {
+
+    @InjectMocks
+    private ProductService productService;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    private Integer size;
+    private Integer pageNo;
+    private LocalDateTime fixTime;
+    Page<Product> mockProducts;
+    @BeforeEach
+    public void setup() {
+        size = 5;
+        pageNo = 0;
+        fixTime = LocalDateTime.now();
+
+        List<Product> productList = List.of(new Product(1L, ProductCategory.FASHION, "바지", BigDecimal.valueOf(50000), fixTime, fixTime),
+                new Product(2L, ProductCategory.ELECTRONICS, "게이밍 노트북", BigDecimal.valueOf(1450000), fixTime, fixTime));
+        Pageable pageable = PageRequest.of(pageNo, size);
+        mockProducts = new PageImpl<>(productList, pageable, productList.size());
+    }
+
+    @Test
+    public void 상품_목록_조회_성공(){
+
+        // given
+        ProductSearchRequest productSearchRequest = ProductSearchRequest.builder().category(ProductCategory.ALL).size(size).pageNo(pageNo).build();
+
+        when(productService.getProducts(productSearchRequest)).thenReturn(mockProducts);
+
+        // when
+        Page<Product> products = productService.getProducts(productSearchRequest);
+
+        // then
+        assertThat(products.getSize()).isEqualTo(size);
+        assertThat(products.getNumber()).isEqualTo(pageNo);
+    }
+
+    @Test
+    public void 상품_목록_금액조건조회_실패(){
+        ProductSearchRequest productSearchRequest = ProductSearchRequest.builder()
+                .minPrice(BigDecimal.valueOf(-1)).maxPrice(BigDecimal.valueOf(3000)).size(size).pageNo(pageNo).build();
+
+        // when
+        ProductException exception = assertThrows(
+                ProductException.class,
+                () -> productService.getProducts(productSearchRequest)
+        );
+
+        assertThat(exception.getCode()).isEqualTo("MIN_PRICE");
+        assertThat(exception.getMessage()).contains("0보다 작을 수 없습니다.");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    public void 상품_목록_페이징조회예외_검증(){
+        ProductSearchRequest productSearchRequest = ProductSearchRequest.builder()
+                .minPrice(BigDecimal.valueOf(0)).maxPrice(BigDecimal.valueOf(3000)).build();
+
+        // when
+        ProductException exception = assertThrows(
+                ProductException.class,
+                () -> productService.getProducts(productSearchRequest)
+        );
+
+        assertThat(exception.getCode()).isEqualTo("MISSING_PAGE_PARAMETER");
+        assertThat(exception.getMessage()).contains("누락");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+}
+
+

--- a/src/test/java/kr/hhplus/be/server/order/OrderServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/order/OrderServiceTest.java
@@ -1,0 +1,78 @@
+package kr.hhplus.be.server.order;
+
+import kr.hhplus.be.server.application.order.dto.OrderProduct;
+import kr.hhplus.be.server.application.order.dto.OrderRequest;
+import kr.hhplus.be.server.application.order.dto.OrderResponse;
+import kr.hhplus.be.server.application.order.service.OrderService;
+import kr.hhplus.be.server.application.product.service.ProductService;
+import kr.hhplus.be.server.domain.order.repository.OrderRepository;
+import kr.hhplus.be.server.domain.product.model.ProductInventory;
+import kr.hhplus.be.server.domain.product.repository.ProductRepository;
+import kr.hhplus.be.server.domain.user.model.UserBalance;
+import kr.hhplus.be.server.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class OrderServiceTest {
+
+    @InjectMocks
+    private OrderService orderService;
+
+    @InjectMocks
+    private ProductService productService;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    private Long userId;
+
+
+    @BeforeEach
+    public void setup() {
+        userId = 1L;
+    }
+
+    @Test
+    public void 주문_생성_테스트(){
+        OrderProduct orderProduct1 = OrderProduct.builder().productId(1L).quantity(2).price(BigDecimal.valueOf(10000)).build();
+        OrderProduct orderProduct2 = OrderProduct.builder().productId(3L).quantity(1).price(BigDecimal.valueOf(54000)).build();
+
+        BigDecimal totalPrice = BigDecimal.valueOf(10000).multiply(BigDecimal.valueOf(2)).add(BigDecimal.valueOf(54000));
+
+        OrderRequest orderRequest = OrderRequest.builder().userId(userId).orderProducts(List.of(orderProduct1, orderProduct2)).build();
+
+        when(userRepository.getUserBalance(userId)).thenReturn(new UserBalance(userId, BigDecimal.valueOf(64000)));
+        // TODO : DB에 저장된 상품 가격 가져와서 매핑하고, 총 결제 금액 계산
+        when(productRepository.getProductPrice(1L)).thenReturn(BigDecimal.valueOf(10000));
+        when(productRepository.getProductPrice(3L)).thenReturn(BigDecimal.valueOf(54000));
+        when(orderRepository.saveOrder(any(Order.class))).thenReturn(1L);
+        when(productRepository.getProductInventory(1L)).thenReturn(ProductInventory.builder().productId(1L).inventory(5).build());
+        when(productRepository.getProductInventory(3L)).thenReturn(ProductInventory.builder().productId(3L).inventory(5).build());
+
+
+        OrderResponse orderResponse = orderService.createOrder(orderRequest);
+
+
+        assertThat(orderResponse.getOrderId()).isEqualTo(1L);
+        assertThat(orderResponse.getFinalPrice()).isEqualTo(totalPrice);
+
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/order/OrderServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/order/OrderServiceTest.java
@@ -4,6 +4,7 @@ import kr.hhplus.be.server.application.order.dto.OrderItem;
 import kr.hhplus.be.server.application.order.dto.OrderRequest;
 import kr.hhplus.be.server.application.order.dto.OrderResponse;
 import kr.hhplus.be.server.application.order.service.OrderService;
+import kr.hhplus.be.server.application.payment.service.PaymentService;
 import kr.hhplus.be.server.application.product.dto.ProductOrderDetail;
 import kr.hhplus.be.server.application.product.dto.ProductOrderResult;
 import kr.hhplus.be.server.application.product.service.ProductService;
@@ -50,6 +51,9 @@ public class OrderServiceTest {
 
     @Mock
     private ProductRepository productRepository;
+
+    @Mock
+    private PaymentService paymentService;
 
     private Long userId;
 

--- a/src/test/java/kr/hhplus/be/server/payment/PaymentServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/payment/PaymentServiceTest.java
@@ -1,0 +1,63 @@
+package kr.hhplus.be.server.payment;
+
+import kr.hhplus.be.server.application.payment.dto.PaymentRequest;
+import kr.hhplus.be.server.application.payment.dto.PaymentResponse;
+import kr.hhplus.be.server.application.payment.service.PaymentService;
+import kr.hhplus.be.server.application.user.dto.UserBalanceRequest;
+import kr.hhplus.be.server.application.user.service.UserService;
+import kr.hhplus.be.server.domain.payment.model.Payment;
+import kr.hhplus.be.server.domain.payment.repository.PaymentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class PaymentServiceTest {
+
+    @InjectMocks
+    private PaymentService paymentService;
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    private Long userId;
+    private Long orderId;
+    private BigDecimal amount;
+
+    @BeforeEach
+    public void setUp() {
+        userId = 1L;
+        orderId = 1L;
+        amount = BigDecimal.valueOf(70000);
+    }
+
+    @Test
+    public void 주문_결제_테스트(){
+        PaymentRequest paymentRequest = new PaymentRequest(userId, orderId, amount);
+        Payment payment = Payment.from(paymentRequest);
+        Payment paymentSetId = Payment.from(paymentRequest);
+        paymentSetId.setId(2L);
+        when(paymentRepository.save(any(Payment.class))).thenReturn(paymentSetId);
+
+        PaymentResponse paymentResponse = PaymentResponse.of(paymentSetId);
+
+        PaymentResponse paymentResult = paymentService.createPayment(paymentRequest);
+
+        assertThat(paymentResult.getOrderId()).isEqualTo(orderId);
+        assertThat(paymentResult.getPaymentId()).isEqualTo(2L);
+
+    }
+
+}

--- a/src/test/java/kr/hhplus/be/server/product/ProductServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/product/ProductServiceTest.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server;
+package kr.hhplus.be.server.product;
 
 
 import kr.hhplus.be.server.application.product.dto.ProductSearchRequest;

--- a/src/test/java/kr/hhplus/be/server/product/ProductServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/product/ProductServiceTest.java
@@ -40,6 +40,7 @@ public class ProductServiceTest {
     private Integer pageNo;
     private LocalDateTime fixTime;
     Page<Product> mockProducts;
+
     @BeforeEach
     public void setup() {
         size = 5;

--- a/src/test/java/kr/hhplus/be/server/product/ProductServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/product/ProductServiceTest.java
@@ -1,11 +1,15 @@
 package kr.hhplus.be.server.product;
 
 
+import kr.hhplus.be.server.application.order.dto.OrderItem;
+import kr.hhplus.be.server.application.product.dto.ProductOrderDetail;
+import kr.hhplus.be.server.application.product.dto.ProductOrderResult;
 import kr.hhplus.be.server.application.product.dto.ProductSearchRequest;
 import kr.hhplus.be.server.application.product.service.ProductService;
 import kr.hhplus.be.server.domain.exception.ProductException;
 import kr.hhplus.be.server.domain.product.enumtype.ProductCategory;
 import kr.hhplus.be.server.domain.product.model.Product;
+import kr.hhplus.be.server.domain.product.model.ProductInventory;
 import kr.hhplus.be.server.domain.product.repository.ProductRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +29,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -99,6 +104,91 @@ public class ProductServiceTest {
         assertThat(exception.getCode()).isEqualTo("MISSING_PAGE_PARAMETER");
         assertThat(exception.getMessage()).contains("누락");
         assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+
+    @Test
+    public void 상품_재고차감_테스트(){
+        ProductInventory productInventory = new ProductInventory(1L, 1);
+        when(productRepository.getProductInventory(1L)).thenReturn(productInventory);
+
+        productService.decreaseProductInventory(1L, 1);
+
+        verify(productRepository).saveProductInventory(productInventory);
+
+    }
+
+    @Test
+    public void 상품_재고차감_수량부족_실패(){
+        ProductInventory productInventory = new ProductInventory(1L, 1);
+        when(productRepository.getProductInventory(1L)).thenReturn(productInventory);
+
+
+        ProductException exception = assertThrows(
+                ProductException.class,
+                () -> productService.decreaseProductInventory(1L, 2)
+        );
+
+        assertThat(exception.getCode()).isEqualTo("OUT_OF_STOCK");
+        assertThat(exception.getMessage()).contains("재고가 부족");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.CONFLICT);
+
+    }
+
+    @Test
+    public void 상품_재고차감_잘못된상품수량_실패(){
+        ProductInventory productInventory = new ProductInventory(1L, 1);
+        when(productRepository.getProductInventory(1L)).thenReturn(productInventory);
+
+
+        ProductException exception = assertThrows(
+                ProductException.class,
+                () -> productService.decreaseProductInventory(1L, 0)
+        );
+
+        assertThat(exception.getCode()).isEqualTo("INVALID_QUANTITY");
+        assertThat(exception.getMessage()).contains("상품을 1개 이상");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    }
+
+    @Test
+    public void 주문상품_가격조회_테스트(){
+        OrderItem orderItem1 = OrderItem.builder().productId(1L).quantity(2).build();
+        OrderItem orderItem2 = OrderItem.builder().productId(3L).quantity(1).build();
+        List<OrderItem> orderItemList = List.of(orderItem1, orderItem2);
+
+        when(productRepository.getProductPrice(1L)).thenReturn(BigDecimal.valueOf(10000));
+        when(productRepository.getProductPrice(3L)).thenReturn(BigDecimal.valueOf(50000));
+
+        ProductOrderDetail product1 = ProductOrderDetail.of(orderItem1, BigDecimal.valueOf(10000));
+        ProductOrderDetail product2 = ProductOrderDetail.of(orderItem2, BigDecimal.valueOf(50000));
+
+        ProductOrderResult productOrderDetail = ProductOrderResult.of(BigDecimal.valueOf(70000), List.of(product1, product2));
+
+        ProductOrderResult result = productService.getProductOrderPrice(orderItemList);
+
+        assertThat(result.getTotalPrice()).isEqualTo(BigDecimal.valueOf(70000));
+
+
+    }
+
+    @Test
+    public void 주문상품_가격조회_상품정보없음_실패(){
+        OrderItem orderItem1 = OrderItem.builder().productId(1L).quantity(2).build();
+        List<OrderItem> orderItemList = List.of(orderItem1);
+
+        when(productRepository.getProductPrice(1L)).thenReturn(null);
+
+        ProductException exception = assertThrows(
+                ProductException.class,
+                () -> productService.getProductOrderPrice(orderItemList)
+        );
+
+        assertThat(exception.getCode()).isEqualTo("PRODUCT_NOT_FOUND");
+        assertThat(exception.getMessage()).contains("존재하지 않는 상품");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+
     }
 
 }

--- a/src/test/java/kr/hhplus/be/server/user/UserServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/user/UserServiceTest.java
@@ -1,0 +1,116 @@
+package kr.hhplus.be.server.user;
+
+import kr.hhplus.be.server.application.user.dto.UserBalanceRequest;
+import kr.hhplus.be.server.application.user.service.UserService;
+import kr.hhplus.be.server.domain.exception.ProductException;
+import kr.hhplus.be.server.domain.exception.UserException;
+import kr.hhplus.be.server.domain.user.model.UserBalance;
+import kr.hhplus.be.server.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private Long id;
+    private BigDecimal balance;
+    private BigDecimal chargeAmount;
+
+    @BeforeEach
+    public void setup() {
+        id = 1L;
+        balance = BigDecimal.valueOf(200000);
+        chargeAmount = BigDecimal.valueOf(100000);
+    }
+
+    @Test
+    public void 잔액_충전_성공(){
+        UserBalanceRequest chargeBalanceRequest = UserBalanceRequest.builder()
+                .id(id).amount(chargeAmount).build();
+        UserBalance userBalance = new UserBalance(id, balance);
+        UserBalance afterChargeUserBalance = new UserBalance(id, balance.add( chargeAmount));
+
+        when(userRepository.getUserBalance(id)).thenReturn(userBalance);
+        when(userRepository.chargeUserBalance(any(UserBalance.class))).thenReturn(1);
+
+        UserBalance userBalanceResult = userService.chargeUserBalance(chargeBalanceRequest);
+
+        assertThat(userBalanceResult.getBalance()).isEqualTo(afterChargeUserBalance.getBalance());
+        assertThat(userBalanceResult.getId()).isEqualTo(afterChargeUserBalance.getId());
+    }
+
+    @Test
+    public void 잔액_충전_실패_사용자없음(){
+        UserBalanceRequest chargeBalanceRequest = UserBalanceRequest.builder()
+                .id(id).amount(chargeAmount).build();
+        when(userRepository.getUserBalance(id)).thenReturn(null);
+
+        UserException exception = assertThrows(
+                UserException.class,
+                () -> userService.chargeUserBalance(chargeBalanceRequest)
+        );
+
+        assertThat(exception.getCode()).isEqualTo("USER_NOT_FOUND");
+        assertThat(exception.getMessage()).contains("사용자를 찾을 수 없습니다.");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+
+    }
+
+    @Test
+    public void 잔액_충전_실패_보유가능잔액초과(){
+        UserBalanceRequest chargeBalanceRequest = UserBalanceRequest.builder()
+                .id(id).amount(chargeAmount).build();
+        UserBalance userBalance = new UserBalance(id, balance.multiply(BigDecimal.valueOf(100)));
+
+        when(userRepository.getUserBalance(id)).thenReturn(userBalance);
+
+        UserException exception = assertThrows(
+                UserException.class,
+                () -> userService.chargeUserBalance(chargeBalanceRequest)
+        );
+
+        assertThat(exception.getCode()).isEqualTo("EXCEED_MAX_BALANCE");
+        assertThat(exception.getMessage()).contains("최대 보유 가능 잔액은 10,000,000원입니다.");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+
+    }
+
+    @Test
+    public void 잔액_충전_실패_충전금액오류(){
+        UserBalanceRequest chargeBalanceRequest = UserBalanceRequest.builder()
+                .id(id).amount(chargeAmount.multiply(BigDecimal.valueOf(100))).build();
+        UserBalance userBalance = new UserBalance(id, balance);
+
+        when(userRepository.getUserBalance(id)).thenReturn(userBalance);
+
+        UserException exception = assertThrows(
+                UserException.class,
+                () -> userService.chargeUserBalance(chargeBalanceRequest)
+        );
+
+        assertThat(exception.getCode()).isEqualTo("MAX_CHARGE_AMOUNT");
+        assertThat(exception.getMessage()).contains("1회 최대 충전 가능 금액");
+        assertThat(exception.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+
+    }
+
+
+}


### PR DESCRIPTION
## 참고 자료

https://developer-been.tistory.com/67
https://velog.io/@hgs-study/saga-1

https://velog.io/@dvmflstm/SAGA-pattern%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%9C-%EB%B6%84%EC%82%B0-%ED%8A%B8%EB%9E%9C%EC%9E%AD%EC%85%98-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0#package-structure

## PR 설명

3e1795e : 상품 조회 개발
b7d3642 : 잔액 충전 개발
244a31e , 6a318e1 : 주문 서비스 개발 (유저 확인 > 상품 촘 금액 계산 > 주문 생성 > 재고 차감 )
6561917, 7b689fb : 결제 서비스 개발 (잔액 차감 > 결제 데이터 생성), 주문 서비스에서 결제 서비스 호출하도록 변경

## 리뷰 포인트

- 테스트 코드 작성 시에 외부 기능은 다 mock 처리하고 비즈니스 로직만 작성하라고 되어 있어서 실제 JPA 쪽 구현은 일단 제외하고 개발했습니다. Domain이랑 JPA Entity는 분리할 계획입니다. 

1. 잔액 충전/사용 시에는 1주차 과제에서 피드백 해주신 Striped<Lock>을 사용했고, 재고 차감 시에는 비관적 락을 사용했습니다. 보통 kafka를 많이 사용하는 것 같긴 한데 DB락이나 synchronized도 많이 활용하는지 궁금합니다.

   - 추가로 잔액/충전 시에 도메인 메서드 호출과 repository 메서드 호출 말고 락을 걸고 처리하는 부분은 동일해서 중복 코드가 많은데 이런 경우에 두 메서드를 합치고 트랜잭션 타입에 따라 if문이나 case문으로 처리하는 게 나을까요? 좋은 방법이 있을지 궁금합니다.

2. 잔액 충전 (b7d3642) 시에 Repository에서 도메인 엔티티 말고, 제가 임의로 구성한 DTO로 반환하게 개발을 했는데, Repository는 전부 도메인 엔티티를 받고, 도메인 엔티티를 반환하는 식으로 구성하는 게 클린 아키텍처에 가까운 걸까요?

3. 주문 서비스(6a318e1)에서 유저 확인 > 상품 가격 조회 > 주문 생성 > 재고 차감 순으로 진행했는데 상품 가격 조회 + 재고 차감을 같이하는 게 더 나을까요? 상품 가격 조회 시에 너무 많은 일을 하는 것 같기도 하고, 재고 차감 시에 락을 걸어서 락 지속 시간이 길어지니까 그대로 분리하는게 맞는 거 같기도 합니다.

4. 현재 구성한 주문이나 결제는 다른 서비스들과 너무 많이 엮여 있는 거 같은데, 주문이 너무 많은 책임을 가지는 것 같아 개선할 수 있는 방법이 있을지 궁금합니다.

5. 결제 실패 후 재고 원복 시에 try - catch 문으로 묶고 catch문에서 이벤트 발행으로 주문 취소를 진행해보려고 합니다. 이전에 saga 패턴을 추천해주셨는데, 지금 구조에서 choreography saga 처럼 event 발행 > eventListener로 처리할까 고민중인데요. @Saga 어노테이션을 쓰지 않고 @TransactionalEventListner로 saga 와 비슷한 방식으로 구현해도 괜찮을까요?

6. 현재 아키텍처 구조와 가장 상위에 각 도메인 명으로 폴더가 있고, 하위에 application, infrastructure를 두는 것 중 어떤 게 더 클린아키텍처에 가깝나요?

7. 강의에서 TPS가 10배 튀면 어떤 레이어부터 병목을 의심하냐는 질문을 고민해보았는데요. 일단은 사용자가 늘면 자연스럽게 TPS가 늘어나고, 어느 지점이 되면 포화점에 도달해 대기 시간이 길어지니 1) 애플리케이션 사용량 2) DB 트랜잭션 처리 부분 3) 여러 서비스로 구성되어 a 서비스에서 b 서비스를 호출하는 경우 b 서비스 4) 네트워크 / 외부 레이어 이 순서를 생각해보았습니다. 완벽한 정답은 없겠지만 제가 생각한 것 중에 알맞지 않은 게 있을지 궁금합니다.

     

## Definition of Done (DoD)

    - [x] 포인트 충전/사용/조회
    - [x] 상품 페이지 조회
    - [x] 주문 서비스 개발
    - [x] 결제 서비스 개발 
    - [ ] 주문 시 쿠폰 사용 (할인)
    - [ ] 쿠폰 다운로드 기능
    - [ ] 실제 JPA 개발 (일단 비즈니스 로직 구성만 진행)
    - [ ] 결제 실패 시 재고 원복 및 주문 실패 로직 구성
    - [ ] Controller 추가